### PR TITLE
Create Muffa Flutter app scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.dart_tool/
+build/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.idea/
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Muffa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Muffa
+
+Muffa is a small Flutter application for managing shared fridge items.
+The app mirrors the design and functionality of the original example web
+implementation.
+
+## Features
+- Bottom navigation with Home, Fridge, Add, Settings, and Account screens
+- Add items via the camera or gallery and detect food names (placeholder)
+- Items stored in Firestore when logged in or locally when offline
+- Filter items by expiration date on the Home screen
+- Switch language, change layout, set filter days, and manage the fridge ID
+- Google sign-in using Firebase Auth
+
+## Setup
+1. Install [Flutter](https://flutter.dev) 3.10 or newer.
+2. Clone this repository and run `flutter pub get`.
+3. Create a Firebase project and copy the configuration files
+   (`google-services.json`/`GoogleService-Info.plist`).
+4. Place your Firebase credentials in `android/app` and `ios/Runner` as usual.
+5. Run the app with `flutter run`.
+
+When Firebase is not configured or you skip sign-in, data is saved locally using
+`SharedPreferences`.
+
+## License
+This project is released under the MIT License. See [LICENSE](LICENSE) for
+details.

--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+class AppLocalizations {
+  AppLocalizations(this.locale);
+
+  final Locale locale;
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const _localizedStrings = {
+    'en': {
+      'home': 'Home',
+      'fridge': 'Fridge',
+      'settings': 'Settings',
+      'account': 'Account',
+      'take_photo': 'Take photo',
+      'choose_photo': 'Choose from gallery',
+      'sign_in_google': 'Sign in with Google',
+      'sign_out': 'Sign out',
+      'logged_in_as': 'Logged in as',
+      'grid_layout': 'Grid layout',
+      'expiration_filter': 'Expiration filter days',
+      'expires': 'Expires',
+      'added_by': 'Added by',
+      'set_filter_days': 'Set filter days',
+      'fridge_id': 'Fridge ID',
+      'set_fridge_id': 'Set fridge ID',
+      'cancel': 'Cancel',
+      'ok': 'OK',
+      'skip': 'Skip',
+      'username_prompt': 'Enter username',
+      'login_or_skip': 'Log in or continue without account',
+      'login': 'Log in',
+    },
+    'it': {
+      'home': 'Home',
+      'fridge': 'Frigo',
+      'settings': 'Impostazioni',
+      'account': 'Account',
+      'take_photo': 'Scatta foto',
+      'choose_photo': 'Scegli dalla galleria',
+      'sign_in_google': 'Accedi con Google',
+      'sign_out': 'Disconnetti',
+      'logged_in_as': 'Accesso come',
+      'grid_layout': 'Griglia',
+      'expiration_filter': 'Filtro giorni scadenza',
+      'expires': 'Scade',
+      'added_by': 'Aggiunto da',
+      'set_filter_days': 'Imposta giorni filtro',
+      'fridge_id': 'ID frigo',
+      'set_fridge_id': 'Imposta ID frigo',
+      'cancel': 'Annulla',
+      'ok': 'OK',
+      'skip': 'Salta',
+      'username_prompt': 'Inserisci nome utente',
+      'login_or_skip': 'Accedi o continua senza account',
+      'login': 'Accedi',
+    },
+  };
+
+  String _translate(String key) {
+    return _localizedStrings[locale.languageCode]?[key] ??
+        _localizedStrings['en']![key]!;
+  }
+
+  String get home => _translate('home');
+  String get fridge => _translate('fridge');
+  String get settings => _translate('settings');
+  String get account => _translate('account');
+  String get takePhoto => _translate('take_photo');
+  String get choosePhoto => _translate('choose_photo');
+  String get signInGoogle => _translate('sign_in_google');
+  String get signOut => _translate('sign_out');
+  String get loggedInAs => _translate('logged_in_as');
+  String get gridLayout => _translate('grid_layout');
+  String get expirationFilter => _translate('expiration_filter');
+  String get expires => _translate('expires');
+  String get addedBy => _translate('added_by');
+  String get setFilterDays => _translate('set_filter_days');
+  String get fridgeId => _translate('fridge_id');
+  String get setFridgeId => _translate('set_fridge_id');
+  String get cancel => _translate('cancel');
+  String get ok => _translate('ok');
+  String get skip => _translate('skip');
+  String get usernamePrompt => _translate('username_prompt');
+  String get loginOrSkip => _translate('login_or_skip');
+  String get login => _translate('login');
+}
+
+class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ['en', 'it'].contains(locale.languageCode);
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+
+  @override
+  bool shouldReload(LocalizationsDelegate<AppLocalizations> old) => false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:provider/provider.dart';
+
+import 'services/app_state.dart';
+import 'screens/home_screen.dart';
+import 'screens/fridge_screen.dart';
+import 'screens/settings_screen.dart';
+import 'screens/account_screen.dart';
+import 'screens/add_item_flow.dart';
+import 'screens/onboarding_screen.dart';
+import 'localization.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const MuffaApp());
+}
+
+class MuffaApp extends StatelessWidget {
+  const MuffaApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => AppState(),
+      child: Consumer<AppState>(
+        builder: (context, state, child) {
+          return MaterialApp(
+            title: 'Muffa',
+            locale: state.locale,
+            supportedLocales: const [Locale('en'), Locale('it')],
+            localizationsDelegates: const [
+              AppLocalizationsDelegate(),
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+            theme: ThemeData(primarySwatch: Colors.green),
+            home: state.username.isEmpty ? const OnboardingScreen() : const MainScaffold(),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class MainScaffold extends StatefulWidget {
+  const MainScaffold({super.key});
+
+  @override
+  State<MainScaffold> createState() => _MainScaffoldState();
+}
+
+class _MainScaffoldState extends State<MainScaffold> {
+  int index = 0;
+
+  final pages = const [
+    HomeScreen(),
+    FridgeScreen(),
+    SizedBox.shrink(),
+    SettingsScreen(),
+    AccountScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: pages[index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: index > 1 ? index - 1 : index,
+        onTap: (i) {
+          if (i == 2) return; // center is FAB
+          setState(() {
+            index = i >= 2 ? i + 1 : i;
+          });
+        },
+        items: [
+          BottomNavigationBarItem(icon: const Icon(Icons.home), label: AppLocalizations.of(context).home),
+          BottomNavigationBarItem(icon: const Icon(Icons.kitchen), label: AppLocalizations.of(context).fridge),
+          BottomNavigationBarItem(icon: const Icon(Icons.settings), label: AppLocalizations.of(context).settings),
+          BottomNavigationBarItem(icon: const Icon(Icons.person), label: AppLocalizations.of(context).account),
+        ],
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => AddItemFlow.start(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/models/food_item.dart
+++ b/lib/models/food_item.dart
@@ -1,0 +1,34 @@
+class FoodItem {
+  final String id;
+  final String name;
+  final DateTime expirationDate;
+  final String addedBy;
+  final DateTime createdAt;
+
+  FoodItem({
+    required this.id,
+    required this.name,
+    required this.expirationDate,
+    required this.addedBy,
+    required this.createdAt,
+  });
+
+  factory FoodItem.fromMap(Map<String, dynamic> data, String id) {
+    return FoodItem(
+      id: id,
+      name: data['name'] ?? '',
+      expirationDate: DateTime.parse(data['expirationDate']),
+      addedBy: data['addedBy'] ?? '',
+      createdAt: DateTime.parse(data['createdAt']),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'expirationDate': expirationDate.toIso8601String(),
+      'addedBy': addedBy,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+}

--- a/lib/screens/account_screen.dart
+++ b/lib/screens/account_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/app_state.dart';
+import '../localization.dart';
+
+class AccountScreen extends StatelessWidget {
+  const AccountScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    return Consumer<AppState>(builder: (context, state, child) {
+      if (state.user == null) {
+        return Center(
+          child: ElevatedButton(
+            onPressed: () => state.signIn(),
+            child: Text(loc.signInGoogle),
+          ),
+        );
+      }
+      return ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text('${loc.loggedInAs} ${state.user!.email}'),
+          ElevatedButton(onPressed: () => state.signOut(), child: Text(loc.signOut)),
+        ],
+      );
+    });
+  }
+}

--- a/lib/screens/add_item_flow.dart
+++ b/lib/screens/add_item_flow.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+
+import '../models/food_item.dart';
+import '../services/app_state.dart';
+import '../services/data_service.dart';
+import '../services/image_recognition.dart';
+import '../localization.dart';
+
+class AddItemFlow {
+  static Future<void> start(BuildContext context) async {
+    final picker = ImagePicker();
+    final loc = AppLocalizations.of(context);
+    final source = await showModalBottomSheet<ImageSource>(
+      context: context,
+      builder: (context) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.photo_camera),
+            title: Text(loc.takePhoto),
+            onTap: () => Navigator.pop(context, ImageSource.camera),
+          ),
+          ListTile(
+            leading: const Icon(Icons.photo_library),
+            title: Text(loc.choosePhoto),
+            onTap: () => Navigator.pop(context, ImageSource.gallery),
+          ),
+        ],
+      ),
+    );
+    if (source == null) return;
+    final picked = await picker.pickImage(source: source);
+    if (picked == null) return;
+    final foods = await recognizeFoodFromImage(picked);
+    final state = context.read<AppState>();
+    for (final food in foods) {
+      final dateStr = await showDialog<String>(
+        context: context,
+        builder: (context) {
+          final controller = TextEditingController();
+          return AlertDialog(
+            title: Text('Expiration date for $food'),
+            content: TextField(
+              controller: controller,
+              decoration: const InputDecoration(hintText: 'YYYY-MM-DD'),
+            ),
+            actions: [
+              TextButton(onPressed: () => Navigator.pop(context), child: Text(loc.skip)),
+              TextButton(onPressed: () => Navigator.pop(context, controller.text), child: Text(loc.ok)),
+            ],
+          );
+        },
+      );
+      final date = dateStr != null && dateStr.isNotEmpty ? DateTime.tryParse(dateStr) ?? DateTime(2099, 12, 31) : DateTime(2099, 12, 31);
+      final item = FoodItem(
+        id: DataService(fridgeId: state.fridgeId, loggedIn: state.user != null).generateId(),
+        name: food,
+        expirationDate: date,
+        addedBy: state.username,
+        createdAt: DateTime.now(),
+      );
+      await state.addItem(item);
+    }
+  }
+}

--- a/lib/screens/fridge_screen.dart
+++ b/lib/screens/fridge_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/app_state.dart';
+import '../widgets/food_tile.dart';
+
+class FridgeScreen extends StatelessWidget {
+  const FridgeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(
+      builder: (context, state, child) {
+        if (state.gridLayout) {
+          return GridView.count(
+            crossAxisCount: 2,
+            children: state.items.map((e) => FoodTile(item: e)).toList(),
+          );
+        }
+        return ListView(
+          children: state.items.map((e) => FoodTile(item: e)).toList(),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/app_state.dart';
+import '../widgets/food_tile.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(
+      builder: (context, state, child) {
+        final now = DateTime.now();
+        final upcoming = state.items.where((item) => item.expirationDate.difference(now).inDays <= state.filterDays).toList();
+        if (state.gridLayout) {
+          return GridView.count(
+            crossAxisCount: 2,
+            children: upcoming.map((e) => FoodTile(item: e)).toList(),
+          );
+        }
+        return ListView(
+          children: upcoming.map((e) => FoodTile(item: e)).toList(),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../localization.dart';
+import '../services/app_state.dart';
+
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _fridgeController = TextEditingController();
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _fridgeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: Text(loc.loginOrSkip)),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Consumer<AppState>(builder: (context, state, child) {
+          return Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: () async {
+                  await state.signIn();
+                },
+                child: Text(loc.login),
+              ),
+              TextButton(
+                onPressed: () {},
+                child: Text(loc.skip),
+              ),
+              const SizedBox(height: 24),
+              TextField(
+                controller: _usernameController,
+                decoration: InputDecoration(labelText: loc.usernamePrompt),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _fridgeController,
+                decoration: InputDecoration(labelText: loc.fridgeId),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  state.setUsername(_usernameController.text);
+                  if (_fridgeController.text.isNotEmpty) {
+                    state.setFridgeId(_fridgeController.text);
+                  }
+                },
+                child: Text(loc.ok),
+              ),
+            ],
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/app_state.dart';
+import '../localization.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<AppState>(
+      builder: (context, state, child) {
+        final loc = AppLocalizations.of(context);
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            DropdownButton<Locale>(
+              value: state.locale,
+              onChanged: (val) {
+                if (val != null) {
+                  state.setLocale(val);
+                }
+              },
+              items: const [
+                DropdownMenuItem(value: Locale('en'), child: Text('English')),
+                DropdownMenuItem(value: Locale('it'), child: Text('Italian')),
+              ],
+            ),
+            SwitchListTile(
+              title: Text(loc.gridLayout),
+              value: state.gridLayout,
+              onChanged: (val) {
+                state.setGridLayout(val);
+              },
+            ),
+            ListTile(
+              title: Text(loc.expirationFilter),
+              trailing: Text(state.filterDays.toString()),
+              onTap: () async {
+                final controller = TextEditingController(text: state.filterDays.toString());
+                final result = await showDialog<String>(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialog(
+                        title: Text(loc.setFilterDays),
+                        content: TextField(controller: controller, keyboardType: TextInputType.number),
+                        actions: [
+                          TextButton(onPressed: () => Navigator.pop(context), child: Text(loc.cancel)),
+                          TextButton(onPressed: () => Navigator.pop(context, controller.text), child: Text(loc.ok)),
+                        ],
+                      );
+                    });
+                if (result != null) {
+                  state.setFilterDays(int.tryParse(result) ?? state.filterDays);
+                }
+              },
+            ),
+            ListTile(
+              title: Text(loc.fridgeId),
+              subtitle: Text(state.fridgeId ?? 'Not set'),
+              onTap: () async {
+                final controller = TextEditingController(text: state.fridgeId);
+                final result = await showDialog<String>(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialog(
+                        title: Text(loc.setFridgeId),
+                        content: TextField(controller: controller),
+                        actions: [
+                          TextButton(onPressed: () => Navigator.pop(context), child: Text(loc.cancel)),
+                          TextButton(onPressed: () => Navigator.pop(context, controller.text), child: Text(loc.ok)),
+                        ],
+                      );
+                    });
+                if (result != null) {
+                  state.setFridgeId(result);
+                }
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/services/app_state.dart
+++ b/lib/services/app_state.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/food_item.dart';
+import 'auth_service.dart';
+import 'data_service.dart';
+
+class AppState extends ChangeNotifier {
+  final AuthService _authService = AuthService();
+  User? user;
+  String username = '';
+  String? fridgeId;
+  bool gridLayout = false;
+  int filterDays = 5;
+  Locale locale = const Locale('en');
+  List<FoodItem> items = [];
+  SharedPreferences? _prefs;
+
+  DataService get _dataService => DataService(fridgeId: fridgeId, loggedIn: user != null);
+
+  AppState() {
+    _init();
+    _authService.userChanges.listen((u) async {
+      user = u;
+      await loadItems();
+      notifyListeners();
+    });
+  }
+
+  Future<void> _init() async {
+    _prefs = await SharedPreferences.getInstance();
+    username = _prefs?.getString('username') ?? '';
+    fridgeId = _prefs?.getString('fridgeId');
+    gridLayout = _prefs?.getBool('gridLayout') ?? false;
+    filterDays = _prefs?.getInt('filterDays') ?? 5;
+    final lang = _prefs?.getString('locale') ?? 'en';
+    locale = Locale(lang);
+    await loadItems();
+  }
+
+  Future<void> loadItems() async {
+    items = await _dataService.getItems();
+    notifyListeners();
+  }
+
+  Future<void> addItem(FoodItem item) async {
+    await _dataService.addItem(item);
+    await loadItems();
+  }
+
+  Future<void> signIn() async {
+    user = await _authService.signInWithGoogle();
+    await loadItems();
+    notifyListeners();
+  }
+
+  Future<void> signOut() async {
+    await _authService.signOut();
+    user = null;
+    await loadItems();
+    notifyListeners();
+  }
+
+  void setUsername(String name) {
+    username = name;
+    _prefs?.setString('username', name);
+    notifyListeners();
+  }
+
+  void setFridgeId(String id) {
+    fridgeId = id;
+    _prefs?.setString('fridgeId', id);
+    loadItems();
+    notifyListeners();
+  }
+
+  void setGridLayout(bool value) {
+    gridLayout = value;
+    _prefs?.setBool('gridLayout', value);
+    notifyListeners();
+  }
+
+  void setFilterDays(int days) {
+    filterDays = days;
+    _prefs?.setInt('filterDays', days);
+    notifyListeners();
+  }
+
+  void setLocale(Locale loc) {
+    locale = loc;
+    _prefs?.setString('locale', loc.languageCode);
+    notifyListeners();
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,25 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+class AuthService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  Stream<User?> get userChanges => _auth.authStateChanges();
+
+  Future<User?> signInWithGoogle() async {
+    final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
+    if (googleUser == null) return null;
+    final googleAuth = await googleUser.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+    final userCredential = await _auth.signInWithCredential(credential);
+    return userCredential.user;
+  }
+
+  Future<void> signOut() async {
+    await _auth.signOut();
+    await GoogleSignIn().signOut();
+  }
+}

--- a/lib/services/data_service.dart
+++ b/lib/services/data_service.dart
@@ -1,0 +1,57 @@
+import 'dart:math';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/food_item.dart';
+
+class DataService {
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+  final String? fridgeId;
+  final bool loggedIn;
+
+  DataService({required this.fridgeId, required this.loggedIn});
+
+  Future<void> addItem(FoodItem item) async {
+    if (loggedIn && fridgeId != null) {
+      await _db.collection('fridges').doc(fridgeId).collection('items').doc(item.id).set(item.toMap());
+    } else {
+      final prefs = await SharedPreferences.getInstance();
+      final items = prefs.getStringList('items') ?? [];
+      items.add(_encodeItem(item));
+      await prefs.setStringList('items', items);
+    }
+  }
+
+  Future<List<FoodItem>> getItems() async {
+    if (loggedIn && fridgeId != null) {
+      final snapshot = await _db.collection('fridges').doc(fridgeId).collection('items').get();
+      return snapshot.docs.map((d) => FoodItem.fromMap(d.data(), d.id)).toList();
+    } else {
+      final prefs = await SharedPreferences.getInstance();
+      final items = prefs.getStringList('items') ?? [];
+      return items.map(_decodeItem).toList();
+    }
+  }
+
+  String _encodeItem(FoodItem item) {
+    return '${item.id}|${item.name}|${item.expirationDate.toIso8601String()}|${item.addedBy}|${item.createdAt.toIso8601String()}';
+  }
+
+  FoodItem _decodeItem(String str) {
+    final parts = str.split('|');
+    return FoodItem(
+      id: parts[0],
+      name: parts[1],
+      expirationDate: DateTime.parse(parts[2]),
+      addedBy: parts[3],
+      createdAt: DateTime.parse(parts[4]),
+    );
+  }
+
+  String generateId() {
+    final rand = Random();
+    const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    return List.generate(12, (index) => chars[rand.nextInt(chars.length)]).join();
+  }
+}

--- a/lib/services/image_recognition.dart
+++ b/lib/services/image_recognition.dart
@@ -1,0 +1,5 @@
+Future<List<String>> recognizeFoodFromImage(dynamic image) async {
+  // Placeholder implementation
+  await Future.delayed(const Duration(seconds: 1));
+  return ['Milk', 'Cheese', 'Eggs'];
+}

--- a/lib/widgets/food_tile.dart
+++ b/lib/widgets/food_tile.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../models/food_item.dart';
+import '../localization.dart';
+
+class FoodTile extends StatelessWidget {
+  final FoodItem item;
+
+  const FoodTile({super.key, required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    return ListTile(
+      title: Text(item.name),
+      subtitle: Text(
+        '${loc.expires}: ${item.expirationDate.toLocal().toString().split(' ')[0]}\n${loc.addedBy}: ${item.addedBy}',
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,23 @@
+name: muffa
+version: 1.0.0+1
+description: A fridge management app.
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.0
+  firebase_core: ^2.0.0
+  firebase_auth: ^4.0.0
+  cloud_firestore: ^4.0.0
+  google_sign_in: ^6.0.0
+  shared_preferences: ^2.0.15
+  image_picker: ^1.0.0
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.18.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add Flutter project files for Muffa
- implement item model, data service and auth
- add app state management with provider
- create screens for home, fridge, settings, account and add item flow
- configure dependencies in `pubspec.yaml`
- add onboarding, localization, and persistence

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68403164c4248327bd544aa82ff7ec33